### PR TITLE
Fix unit tests failing on Windows. Closes #1

### DIFF
--- a/src/test/java/com/tinify/ClientTest.java
+++ b/src/test/java/com/tinify/ClientTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.*;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -91,11 +92,11 @@ public class ClientTest {
     }
 
     @Test
-    public void requestWhenValidShouldReturnResponse() throws Exception, InterruptedException, IOException {
+    public void requestWhenValidShouldReturnResponse() throws Exception, InterruptedException, IOException, URISyntaxException {
         enqueuShrink();
 
         byte[] body = Files.readAllBytes(
-                Paths.get(getClass().getResource("/example.png").getFile()));
+                Paths.get(getClass().getResource("/example.png").toURI()));
 
         assertEquals("https://api.tinify.com/foo.png",
                 subject.request(Client.Method.POST, "/shrink", body).header("Location"));

--- a/src/test/java/com/tinify/Integration.java
+++ b/src/test/java/com/tinify/Integration.java
@@ -3,9 +3,11 @@ package com.tinify;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.io.File;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -14,7 +16,7 @@ public class Integration {
     private static Source optimized;
 
     @BeforeClass
-    public static void setup() throws java.io.IOException {
+    public static void setup() throws java.io.IOException, URISyntaxException {
         String key = System.getenv().get("TINIFY_KEY");
         if (key == null) {
             System.out.println("Set the TINIFY_KEY environment variable.");
@@ -23,7 +25,7 @@ public class Integration {
 
         Tinify.setKey(key);
 
-        String unoptimizedPath = Integration.class.getResource("/voormedia.png").getFile();
+        String unoptimizedPath = Paths.get(Integration.class.getResource("/voormedia.png").toURI()).toAbsolutePath().toString();
         optimized = Tinify.fromFile(unoptimizedPath);
     }
 

--- a/src/test/java/com/tinify/SourceTest.java
+++ b/src/test/java/com/tinify/SourceTest.java
@@ -12,8 +12,10 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.*;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -56,14 +58,15 @@ public class SourceTest {
     }
 
     @Test(expected = AccountException.class)
-    public void withInvalidApiKeyFromFileShouldThrowAccountException() throws Exception, IOException {
+    public void withInvalidApiKeyFromFileShouldThrowAccountException() throws Exception, IOException, URISyntaxException {
         Tinify.setKey("invalid");
 
         server.enqueue(new MockResponse()
                 .setResponseCode(401)
                 .setBody("{'error':'Unauthorized','message':'Credentials are invalid'}"));
 
-        Source.fromFile(getClass().getResource("/dummy.png").getFile());
+        String filePath = Paths.get(getClass().getResource("/dummy.png").toURI()).toAbsolutePath().toString();
+        Source.fromFile(filePath);
     }
 
     @Test(expected = AccountException.class)
@@ -78,7 +81,7 @@ public class SourceTest {
     }
 
     @Test
-    public void withValidApiKeyFromFileShouldReturnSource() throws IOException, Exception {
+    public void withValidApiKeyFromFileShouldReturnSource() throws IOException, Exception, URISyntaxException {
         Tinify.setKey("valid");
 
         server.enqueue(new MockResponse()
@@ -86,11 +89,12 @@ public class SourceTest {
                 .addHeader("Location", "https://api.tinify.com/some/location")
                 .addHeader("Compression-Count", 12));
 
-        assertThat(Source.fromFile(getClass().getResource("/dummy.png").getFile()), isA(Source.class));
+        String filePath = Paths.get(getClass().getResource("/dummy.png").toURI()).toAbsolutePath().toString();
+        assertThat(Source.fromFile(filePath), isA(Source.class));
     }
 
     @Test
-    public void withValidApiKeyFromFileShouldReturnSourceWithData() throws IOException, Exception {
+    public void withValidApiKeyFromFileShouldReturnSourceWithData() throws IOException, Exception, URISyntaxException {
         Tinify.setKey("valid");
 
         server.enqueue(new MockResponse()
@@ -101,8 +105,8 @@ public class SourceTest {
                 .setResponseCode(200)
                 .setBody("compressed file"));
 
-        assertThat(Source.fromFile(getClass().getResource("/dummy.png").getFile()).toBuffer(),
-                is(equalTo("compressed file".getBytes())));
+        String filePath = Paths.get(getClass().getResource("/dummy.png").toURI()).toAbsolutePath().toString();
+        assertThat(Source.fromFile(filePath).toBuffer(), is(equalTo("compressed file".getBytes())));
     }
 
     @Test

--- a/src/test/java/com/tinify/TinifyTest.java
+++ b/src/test/java/com/tinify/TinifyTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.*;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -126,7 +128,7 @@ public class TinifyTest {
     }
 
     @Test
-    public void fromFileShouldReturnSource() throws IOException {
+    public void fromFileShouldReturnSource() throws IOException, URISyntaxException {
         Tinify.setKey("valid");
 
         server.enqueue(new MockResponse()
@@ -134,7 +136,7 @@ public class TinifyTest {
                 .addHeader("Location", "https://api.tinify.com/some/location")
                 .addHeader("Compression-Count", 12));
 
-        assertThat(Tinify.fromFile(getClass().getResource("/dummy.png").getFile()),
-                isA(Source.class));
+        String filePath = Paths.get(getClass().getResource("/dummy.png").toURI()).toAbsolutePath().toString();
+        assertThat(Tinify.fromFile(filePath), isA(Source.class));
     }
 }


### PR DESCRIPTION
Aparently on Windows `class.getResource().getFile()` returns invalid file paths that can not be parsed by `Paths.get(String)`.  

Example: `Illegal char <:> at index 2: /d:/dev/projects/github/tinify-java/target/test-classes/example.png`

Using `class.getResource().toURI()` produces a `file:/D:/dev/projects/github/tinify-java/target/test-classes/example.png` URI that can be parsed correctly by `Paths.get(URI)`