### PR TITLE
Update gson to avoid CVE-2022-25647.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.9</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix for issue https://github.com/tinify/tinify-java/issues/12 